### PR TITLE
Add logging models as wandb artifacts

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -117,6 +117,7 @@ def run_active_learning_pipeline(
         entity="active-segmentation",
         name=experiment_name,
         tags=experiment_tags,
+        log_model="all",
         config=locals().copy(),
     )
 


### PR DESCRIPTION
closes #61 

This will create an artefact for each checkpoint during training, named `model-run_id:version`. E.g. "model-15xnat09:v2"
We could then download and use these models with `wandb.run.use_artifact("model-15xnat09:v2")`