### PR TITLE
Add dropout layer to U-net architecture

### DIFF
--- a/src/models/pytorch_u_net.py
+++ b/src/models/pytorch_u_net.py
@@ -22,6 +22,8 @@ class PytorchUNet(PytorchModel):
         multi_label (bool, optional): Whether the model should produce single-label or multi-label outputs. If set to
             `False`, the model's predictions are computed using a Softmax activation layer. to If set to `True`, sigmoid
             activation layers are used to compute the model's predicitions. Defaults to False.
+        p_dropout (float, optional): Probability of applying dropout to the outputs of the encoder layers. Defaults to
+            0.
         **kwargs: Further, dataset specific parameters.
     """
 
@@ -32,6 +34,7 @@ class PytorchUNet(PytorchModel):
         in_channels=1,
         out_channels=2,
         multi_label=False,
+        p_dropout: float = 0,
         **kwargs
     ):
 
@@ -43,6 +46,7 @@ class PytorchUNet(PytorchModel):
         self.in_channels = in_channels
         self.out_channels = out_channels
         self.multi_label = multi_label
+        self.p_dropout = p_dropout
 
         self.model = UNet(
             in_channels=self.in_channels,
@@ -51,6 +55,7 @@ class PytorchUNet(PytorchModel):
             init_features=32,
             num_levels=self.num_levels,
             dim=self.dim,
+            p_dropout=self.p_dropout,
         )
 
     def input_dimensionality(self) -> int:
@@ -208,4 +213,5 @@ class PytorchUNet(PytorchModel):
             init_features=32,
             num_levels=self.num_levels,
             dim=self.dim,
+            p_dropout=self.p_dropout,
         )


### PR DESCRIPTION
Add an optional dropout layer to the U-Net architecture. The dropout is applied after each encoding block.