### PR TITLE
Disable deterministic mode

### DIFF
--- a/src/active_learning.py
+++ b/src/active_learning.py
@@ -170,7 +170,7 @@ class ActiveLearningPipeline:
         callbacks.append(checkpoint_callback)
 
         return Trainer(
-            deterministic=True,
+            deterministic=False,
             profiler="simple",
             max_epochs=epochs + iteration * self.epochs_increase_per_query,
             logger=self.logger,


### PR DESCRIPTION
This PR disables the deterministic mode of Pytorch / Pytorch lightning since there is no deterministic implementation of 3d maxpooling in Pytorch. So training a 3d model, currently results in the following error:

`
max_pool3d_with_indices_backward_cuda does not have a deterministic implementation, but you set 'torch.use_deterministic_algorithms(True)'
`